### PR TITLE
Use {yyjsonr}

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,8 @@ Imports:
     tidyselect,
     uuid,
     vctrs (>= 0.6),
-    wk (>= 0.9)
+    wk (>= 0.9),
+    yyjsonr
 Suggests:
     geojsonsf,
     knitr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 - Rescalers no longer require `center` to be inside input domain (#103)
 - All layers now support geometry vectors which {wk} can read (#104)
 - Feature editor accepts geometry vectors which {wk} can read (#105)
+- Use {yyjsonr} for faster serialisation (#110)
 
 # rdeck 0.5.2
 

--- a/R/json.R
+++ b/R/json.R
@@ -195,14 +195,8 @@ as_json.layer_data <- function(object, cols, dims, ...) {
   compiled <- deckgl_table(data, dims)
   compiled$length <- jsonlite::unbox(compiled$length)
 
-  # 6-digit precision for all sf cols
-  compiled$columns <- purrr::map_at(
-    compiled$columns,
-    geom_cols,
-    json_stringify,
-    digits = 6L
-  )
-
+  # 6-digit precision for all cols
+  compiled$columns <- yyjsonr_stringify(compiled$columns, digits = 6)
   json_stringify(compiled, use_signif = TRUE)
 }
 
@@ -241,4 +235,18 @@ json_stringify <- function(object,
     json_verbatim = json_verbatim,
     ...
   )
+}
+
+# experimental yyjsonr serialise
+yyjsonr_stringify <- function(object, camel_case = FALSE, ...) {
+  if (camel_case) {
+    names(object) <- to_camel_case(names(object))
+  }
+
+  json <- yyjsonr::write_json_str(
+    object,
+    list(...)
+  )
+
+  structure(json, class = "json")
 }

--- a/man/wk-geometry.Rd
+++ b/man/wk-geometry.Rd
@@ -24,7 +24,7 @@ Geometry formats supported by \{wk\} (always supported):
 Geometry formats supported by other packages (not dependencies of \{rdeck\}):
 \itemize{
 \item \code{\link[s2:as_s2_geography]{s2::s2_geography()}}
-\item \code{\link[geos:as_geos_geometry]{geos::geos_geometry()}}
+\item \code{\link[geos:geos_geometry]{geos::geos_geometry()}}
 \item Others?
 }
 }


### PR DESCRIPTION
Uses {yyjsonr} to serialise layer dataframes (excluding geojson layer).